### PR TITLE
refactor: 's/execute_script/execute_python/'

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ This package is a thin Python driver around [`bubblewrap`](https://github.com/co
 3. `workdir_sandbox_args(workdir)` — if a host workdir is given, bind-mounts it **read-write** at `/sandbox/work` and `--chdir`s into it. `execute_script` allocates a `TemporaryDirectory` workdir when none is provided and writes `script.py` into it.
 4. `volumes_sandbox_args(volume_map)` — for each `VolumeInfo`: bind-mount at `/sandbox/volumes/<name>` (rw or ro based on `writable`), or create an empty dir when `host_path` is `None`.
 
-`BwrapSandbox.execute` runs the resulting argv via `asyncio.create_subprocess_exec`, enforces `config.execution_timeout_seconds` with `asyncio.wait_for` (returns `exit_code=-1` on timeout), decodes stdout+stderr, and truncates to `config.max_output_chars`. `execute_script` is just a wrapper that writes the script to the workdir and invokes `/sandbox/venv/bin/python /sandbox/work/script.py`.
+`BwrapSandbox.execute` runs the resulting argv via `asyncio.create_subprocess_exec`, enforces `config.execution_timeout_seconds` with `asyncio.wait_for` (returns `exit_code=-1` on timeout), decodes stdout+stderr, and truncates to `config.max_output_chars`. `execute_python` is just a wrapper that writes the script to the workdir and invokes `/sandbox/venv/bin/python /sandbox/work/script.py`. `execute_script` is kept as a backward-compat alias for `execute_python`.
 
 ### Environments are separate uv projects
 
@@ -60,7 +60,7 @@ Each directory under `environments/` is its own `pyproject.toml` project with it
 
 ### CLI
 
-`src/bubble_sandbox/cli/__init__.py` is a Typer app with four commands: `list-environments`, `exec-script` (script string or file), `execute` (argv, no shell), `exec-command` (wraps argv in `sh -c`). `-a/--agent-mode` switches from Rich-decorated output to machine-parseable form (JSON for `list-environments`, raw stdout for the exec commands) — when adding new CLI output, honor this flag so agent callers get clean output.
+`src/bubble_sandbox/cli/__init__.py` is a Typer app with these commands: `list-environments`, `execute-python` (script string or file), `execute` (argv, no shell), `exec-command` (wraps argv in `sh -c`). `exec-script` is kept as a deprecated alias that forwards to `execute-python`. `-a/--agent-mode` switches from Rich-decorated output to machine-parseable form (JSON for `list-environments`, raw stdout for the exec commands) — when adding new CLI output, honor this flag so agent callers get clean output.
 
 ### Tests
 

--- a/src/bubble_sandbox/cli/__init__.py
+++ b/src/bubble_sandbox/cli/__init__.py
@@ -201,9 +201,9 @@ def print_response(
 
 
 @the_cli.command(
-    "exec-script",
+    "execute-python",
 )
-def exec_script(
+def execute_python(
     ctx: typer.Context,
     config_file: pathlib.Path = config_file_option,
     script: str | None = script_option,
@@ -213,7 +213,7 @@ def exec_script(
     volumes: list[str] = volume_option,
     agent_mode: bool = agent_mode_option,
 ):
-    """Run a script / script file in a given environment"""
+    """Run a Python script / script file in a given environment"""
     the_sandbox = make_sandbox(
         config_file=config_file,
         environment_name=environment_name,
@@ -233,14 +233,14 @@ def exec_script(
 
     if workdir is not None:
         response = asyncio.run(
-            the_sandbox.execute_script(
+            the_sandbox.execute_python(
                 script=script,
                 workdir=workdir,
             )
         )
     else:
         response = asyncio.run(
-            the_sandbox.execute_script(
+            the_sandbox.execute_python(
                 script=script,
             )
         )
@@ -249,6 +249,32 @@ def exec_script(
         print_agent_mode_response(response)
     else:
         print_response(response, the_console)
+
+
+@the_cli.command(
+    "exec-script",
+)
+def exec_script(
+    ctx: typer.Context,
+    config_file: pathlib.Path = config_file_option,
+    script: str | None = script_option,
+    script_file: pathlib.Path | None = script_file_option,
+    environment_name: str = environment_name_option,
+    workdir: pathlib.Path | None = workdir_option,
+    volumes: list[str] = volume_option,
+    agent_mode: bool = agent_mode_option,
+):
+    """Deprecated alias for 'execute-python'"""
+    execute_python(
+        ctx=ctx,
+        config_file=config_file,
+        script=script,
+        script_file=script_file,
+        environment_name=environment_name,
+        workdir=workdir,
+        volumes=volumes,
+        agent_mode=agent_mode,
+    )
 
 
 @the_cli.command(

--- a/src/bubble_sandbox/sandbox.py
+++ b/src/bubble_sandbox/sandbox.py
@@ -168,7 +168,7 @@ class BwrapSandbox:
             + command
         )
 
-    async def execute_script(
+    async def execute_python(
         self,
         *,
         script: str,
@@ -203,6 +203,8 @@ class BwrapSandbox:
                 extra_volumes=extra_volumes,
                 extra_args=extra_args,
             )
+
+    execute_script = execute_python  # backward-compat
 
     async def execute(
         self,

--- a/tests/functional/test_sandbox_functional.py
+++ b/tests/functional/test_sandbox_functional.py
@@ -2,7 +2,7 @@ from bubble_sandbox import models as bs_models
 from bubble_sandbox import sandbox as bs_sandbox
 
 
-async def test_bwrapsandboxcommand_execute_script_wo_workdir(
+async def test_bwrapsandboxcommand_execute_python_wo_workdir(
     sandbox_config,
     bare_environment,
 ):
@@ -13,14 +13,14 @@ async def test_bwrapsandboxcommand_execute_script_wo_workdir(
         config=sandbox_config,
     )
 
-    found = await sandbox.execute_script(script=script)
+    found = await sandbox.execute_python(script=script)
 
     assert isinstance(found, bs_models.ExecuteResult)
     assert found.output.startswith("/sandbox/work")
     assert not found.truncated
 
 
-async def test_bwrapsandboxcommand_execute_script_w_workdir(
+async def test_bwrapsandboxcommand_execute_python_w_workdir(
     tmp_path,
     sandbox_config,
     bare_environment,
@@ -35,14 +35,14 @@ async def test_bwrapsandboxcommand_execute_script_w_workdir(
         config=sandbox_config,
     )
 
-    found = await sandbox.execute_script(script=script, workdir=workdir)
+    found = await sandbox.execute_python(script=script, workdir=workdir)
 
     assert isinstance(found, bs_models.ExecuteResult)
     assert found.output.startswith("/sandbox/work")
     assert not found.truncated
 
 
-async def test_bwrapsandboxcommand_execute_script_w_truncation(
+async def test_bwrapsandboxcommand_execute_python_w_truncation(
     sandbox_config,
     bare_environment,
 ):
@@ -54,7 +54,7 @@ async def test_bwrapsandboxcommand_execute_script_w_truncation(
         config=sandbox_config,
     )
 
-    found = await sandbox.execute_script(script=script)
+    found = await sandbox.execute_python(script=script)
 
     assert isinstance(found, bs_models.ExecuteResult)
     assert found.output == "X" * 10

--- a/tests/unit/test_sandbox.py
+++ b/tests/unit/test_sandbox.py
@@ -353,7 +353,7 @@ def test_bwrapsandboxcommand_build_bwrap_command(
 @pytest.mark.parametrize("w_workdir", [False, True])
 @mock.patch("tempfile.TemporaryDirectory")
 @mock.patch("asyncio.create_subprocess_exec")
-async def test_bwrapsandboxcommand_execute_script_w_success(
+async def test_bwrapsandboxcommand_execute_python_w_success(
     cs_exec,
     tftd,
     tmp_path,
@@ -384,7 +384,7 @@ async def test_bwrapsandboxcommand_execute_script_w_success(
         config=sandbox_config,
     )
 
-    found = await sandbox.execute_script(
+    found = await sandbox.execute_python(
         script=script,
         **kwargs,
         **xtra_vols_kwargs,
@@ -418,7 +418,7 @@ async def test_bwrapsandboxcommand_execute_script_w_success(
 
 @pytest.mark.asyncio
 @mock.patch("asyncio.create_subprocess_exec")
-async def test_bwrapsandboxcommand_execute_script_w_truncation(
+async def test_bwrapsandboxcommand_execute_python_w_truncation(
     cs_exec,
     tmp_path,
     sandbox_config,
@@ -441,7 +441,7 @@ async def test_bwrapsandboxcommand_execute_script_w_truncation(
         config=sandbox_config,
     )
 
-    found = await sandbox.execute_script(script=script, workdir=workdir)
+    found = await sandbox.execute_python(script=script, workdir=workdir)
     exp_output = MUST_TRUNCATE[:50].decode("ascii")
 
     assert isinstance(found, bs_models.ExecuteResult)
@@ -462,7 +462,7 @@ async def test_bwrapsandboxcommand_execute_script_w_truncation(
 
 @pytest.mark.asyncio
 @mock.patch("asyncio.create_subprocess_exec")
-async def test_bwrapsandboxcommand_execute_script_w_error(
+async def test_bwrapsandboxcommand_execute_python_w_error(
     cs_exec,
     tmp_path,
     sandbox_config,
@@ -482,7 +482,7 @@ async def test_bwrapsandboxcommand_execute_script_w_error(
         config=sandbox_config,
     )
 
-    found = await sandbox.execute_script(script=script, workdir=workdir)
+    found = await sandbox.execute_python(script=script, workdir=workdir)
 
     assert isinstance(found, bs_models.ExecuteResult)
     assert found.output == "error"
@@ -492,7 +492,7 @@ async def test_bwrapsandboxcommand_execute_script_w_error(
 @pytest.mark.asyncio
 @mock.patch("asyncio.wait_for")
 @mock.patch("asyncio.create_subprocess_exec")
-async def test_bwrapsandboxcommand_execute_script_w_timeout(
+async def test_bwrapsandboxcommand_execute_python_w_timeout(
     cs_exec,
     wait_for,
     tmp_path,
@@ -519,7 +519,7 @@ async def test_bwrapsandboxcommand_execute_script_w_timeout(
         config=sandbox_config,
     )
 
-    found = await sandbox.execute_script(
+    found = await sandbox.execute_python(
         script=script,
         workdir=workdir,
         timeout=timeout_seconds,


### PR DESCRIPTION
- Leave behind a deprecated 'execute_script' alias.

refactor: CLI 's/exec-script/execute-python/'

- Leave behind a deprecated 'exec-script' alias.