### PR TITLE
ci: move workflows to Node 24 actions

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -8,9 +8,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version-file: "pyproject.toml"
       - name: Install build and twine

--- a/.github/workflows/python-lint.yaml
+++ b/.github/workflows/python-lint.yaml
@@ -31,7 +31,7 @@ jobs:
         os: [ubuntu-latest]
         python-version: ["3.13"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6

--- a/.github/workflows/python-test.yaml
+++ b/.github/workflows/python-test.yaml
@@ -35,7 +35,7 @@ jobs:
             - python-version: "3.12"
               pytest-args: "--no-cov"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6


### PR DESCRIPTION
Bump JavaScript actions still on the deprecated Node 20 runtime to their Node 24-native versions ahead of the 2026-06-26 cutover:

- actions/checkout@v4 -> @v6
- astral-sh/setup-uv@v6 -> @v7

Closes #21.